### PR TITLE
feat: default arm-runs-on to GitHub-hosted ubuntu-24.04-arm

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   arm-runs-on:
     description: Builder to use when building on arm
     required: false
-    default: buildjet-2vcpu-ubuntu-2204-arm
+    default: ubuntu-24.04-arm
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary
- Switches the default value of the `arm-runs-on` input from `buildjet-2vcpu-ubuntu-2204-arm` to `ubuntu-24.04-arm`.
- GitHub-hosted ARM64 runners are now GA for public repositories, so consumers no longer need to pay for / configure BuildJet just to get an aarch64 builder.
- Consumers that still want BuildJet (or any other label) can keep overriding via `vars.arm_runner`, which is already wired through `pkgbuild.yml` in `action-bootstrap-actions`.

## Test plan
- [ ] Trigger a downstream `pkgbuild.yml` run on a package with `arch=(aarch64)` and confirm the matrix resolves to `ubuntu-24.04-arm` and builds successfully inside the `manjarolinux/build:latest` container.
- [ ] Confirm packages that override `vars.arm_runner` still pick up the override.